### PR TITLE
🔧 chore(gitignore): add '.venv/' to ignore virtual environment directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignorar ambiente virtual
+.venv/
 venv/
 
 # Ignorar arquivos de cache do Python


### PR DESCRIPTION
📄 Updated the .gitignore file to exclude the '.venv/' directory, ensuring the virtual environment is not tracked by Git, which is a common practice in Python projects.