### PR TITLE
🐛 fix(startup): set default folder to '.venv'

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -5,7 +5,7 @@ Set-Location -Path (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 if (-Not (Test-Path ".\.venv"))
 {
     Write-Host "Criando o ambiente virtual..."
-    python -m venv venv
+    python -m venv .venv
 }
 
 # Ativa o ambiente virtual


### PR DESCRIPTION
🛠 Updated the PowerShell script 'start.ps1' to use '.venv' as the default directory for creating the Python virtual environment.